### PR TITLE
v2.1.2 — finish primitive-return wrap (#10) + Database UX (#14)

### DIFF
--- a/lib/SiYuanClient.ts
+++ b/lib/SiYuanClient.ts
@@ -969,6 +969,23 @@ export class SiYuanClient {
 	// Database (AttributeView) operations
 	// ---------------------------------------------------------------------------
 
+	/**
+	 * Resolves the hosting block ID for a given AttributeView ID by scanning all av-typed
+	 * blocks for the matching `data-av-id`. Throws if no block hosts that AV.
+	 */
+	async getBlockIdByAvId(avID: string): Promise<string> {
+		const rows = (await this.sqlQuery(
+			"SELECT id, markdown FROM blocks WHERE type = 'av'",
+		)) as Array<{ id: string; markdown: string }>;
+
+		for (const row of rows) {
+			if (extractAvIdFromMarkdown(row.markdown || '') === avID) {
+				return row.id;
+			}
+		}
+		throw new Error(`No database block found for AV ID ${avID}`);
+	}
+
 	/** Lists all database (AttributeView) blocks across the workspace. */
 	async listDatabaseBlocks(): Promise<DatabaseBlockLocator[]> {
 		const rows = (await this.sqlQuery(

--- a/nodes/SiYuan/actions/asset/asset.handler.ts
+++ b/nodes/SiYuan/actions/asset/asset.handler.ts
@@ -14,7 +14,8 @@ export async function handleAssetOperation(
 		}
 		case 'getFile': {
 			const path = ctx.getNodeParameter('filePath', itemIndex) as string;
-			return client.getFile(path);
+			const content = await client.getFile(path);
+			return { path, content: content ?? '' };
 		}
 		case 'putFile': {
 			const path = ctx.getNodeParameter('filePath', itemIndex) as string;

--- a/nodes/SiYuan/actions/block/block.handler.ts
+++ b/nodes/SiYuan/actions/block/block.handler.ts
@@ -85,7 +85,8 @@ export async function handleBlockOperation(
 		}
 		case 'getContentMd': {
 			const blockId = ctx.getNodeParameter('blockId', itemIndex) as string;
-			return client.getBlockContentMd(blockId);
+			const content = await client.getBlockContentMd(blockId);
+			return { id: blockId, content: content ?? '' };
 		}
 		default:
 			throw new Error(`Unsupported block operation: ${operation}`);

--- a/nodes/SiYuan/actions/database/database.description.ts
+++ b/nodes/SiYuan/actions/database/database.description.ts
@@ -102,9 +102,10 @@ export const databaseFields: INodeProperties[] = [
 		displayName: 'Database Block ID',
 		name: 'databaseBlockId',
 		type: 'string',
-		required: true,
+		required: false,
 		default: '',
-		description: 'The block ID of the database (the editor block hosting the AttributeView)',
+		description:
+			'Optional — leave blank to auto-resolve from the AV ID. Set explicitly to skip the lookup (one SQL round-trip) if you already have the hosting block ID.',
 		displayOptions: { show: { resource: ['database'], operation: ['addRow'] } },
 	},
 	{
@@ -140,21 +141,23 @@ export const databaseFields: INodeProperties[] = [
 		displayName: 'Fields Mode',
 		name: 'fieldsMode',
 		type: 'options',
-		default: 'byKeyId',
+		default: 'byColumnName',
 		description: 'How to identify the columns to set',
 		displayOptions: {
 			show: { resource: ['database'], operation: ['addRow'], addRowMode: ['fields'] },
 		},
 		options: [
 			{
-				name: 'By Column (Key) ID',
-				value: 'byKeyId',
-				description: 'Repeat field with explicit keyID + value entries',
-			},
-			{
 				name: 'By Column Name (JSON)',
 				value: 'byColumnName',
-				description: 'JSON object mapping column display names to values',
+				description:
+					'JSON object mapping column display names to values — recommended for most use cases',
+			},
+			{
+				name: 'By Column (Key) ID',
+				value: 'byKeyId',
+				description:
+					'Repeat field with explicit keyID + value entries — use when you have the internal column IDs',
 			},
 		],
 	},
@@ -239,11 +242,11 @@ export const databaseFields: INodeProperties[] = [
 		displayName: 'Filter (JSON)',
 		name: 'getFilter',
 		type: 'string',
-		typeOptions: { rows: 3 },
+		typeOptions: { rows: 4 },
 		default: '',
-		placeholder: '{ "Done": true }',
+		placeholder: '{ "Status": ["Done", "WIP"] }',
 		description:
-			'Optional JSON object — only rows where every field matches will be returned. Applied client-side after fetch.',
+			'Optional JSON object — applied client-side after fetch. Scalar values match by equality and combine with AND across keys. Array values match any-of (OR) within that column. Examples: {"Status":"Done","Owner":"Mike"} (AND); {"Status":["Done","WIP"]} (OR on one column); {"Status":["Done","WIP"],"Owner":"Mike"} (mixed).',
 		displayOptions: { show: { resource: ['database'], operation: ['get'] } },
 	},
 	{

--- a/nodes/SiYuan/actions/database/database.handler.ts
+++ b/nodes/SiYuan/actions/database/database.handler.ts
@@ -19,11 +19,27 @@ function flattenRow(
 	return flat;
 }
 
-/** Apply a simple equality filter (top-level field === value) to a list of flat rows. */
+/**
+ * Apply an equality filter to a list of flat rows.
+ *
+ * - Scalar value: equality match (AND across keys).
+ * - Array value: any-of match for that column (OR within the column).
+ *
+ * Examples:
+ *   {"Status":"Done","Owner":"Mike"}        // AND
+ *   {"Status":["Done","WIP"]}               // OR on one column
+ *   {"Status":["Done","WIP"],"Owner":"Mike"} // mixed
+ */
 function applyFilter(rows: Record<string, unknown>[], filter: Record<string, unknown>): Record<string, unknown>[] {
 	const keys = Object.keys(filter);
 	if (keys.length === 0) return rows;
-	return rows.filter((r) => keys.every((k) => r[k] === filter[k]));
+	return rows.filter((row) =>
+		keys.every((k) => {
+			const expected = filter[k];
+			if (Array.isArray(expected)) return expected.some((v) => row[k] === v);
+			return row[k] === expected;
+		}),
+	);
 }
 
 export async function handleDatabaseOperation(
@@ -117,7 +133,10 @@ export async function handleDatabaseOperation(
 
 		case 'addRow': {
 			const avId = ctx.getNodeParameter('avId', itemIndex) as string;
-			const databaseBlockId = ctx.getNodeParameter('databaseBlockId', itemIndex) as string;
+			const databaseBlockIdRaw = ctx.getNodeParameter('databaseBlockId', itemIndex, '') as string;
+			const databaseBlockId = (databaseBlockIdRaw || '').trim().length > 0
+				? databaseBlockIdRaw.trim()
+				: await client.getBlockIdByAvId(avId);
 			const primaryContent = ctx.getNodeParameter('primaryKeyContent', itemIndex, '') as string;
 			const addRowMode = ctx.getNodeParameter('addRowMode', itemIndex, 'simple') as
 				| 'simple'
@@ -127,7 +146,7 @@ export async function handleDatabaseOperation(
 
 			let fieldsSet = 0;
 			if (addRowMode === 'fields') {
-				const fieldsMode = ctx.getNodeParameter('fieldsMode', itemIndex, 'byKeyId') as
+				const fieldsMode = ctx.getNodeParameter('fieldsMode', itemIndex, 'byColumnName') as
 					| 'byKeyId'
 					| 'byColumnName';
 
@@ -175,7 +194,13 @@ export async function handleDatabaseOperation(
 				}
 			}
 
-			return { avID: avId, rowID, primaryKeyContent: primaryContent, fieldsSet };
+			return {
+				avID: avId,
+				databaseBlockId,
+				rowID,
+				primaryKeyContent: primaryContent,
+				fieldsSet,
+			};
 		}
 
 		case 'removeRow': {

--- a/nodes/SiYuan/actions/document/document.handler.ts
+++ b/nodes/SiYuan/actions/document/document.handler.ts
@@ -12,7 +12,8 @@ export async function handleDocumentOperation(
 			const notebookId = ctx.getNodeParameter('notebookId', itemIndex) as string;
 			const docPath = ctx.getNodeParameter('docPath', itemIndex) as string;
 			const markdown = ctx.getNodeParameter('markdownContent', itemIndex) as string;
-			return client.createDocWithMd(notebookId, docPath, markdown);
+			const id = await client.createDocWithMd(notebookId, docPath, markdown);
+			return { id, notebookId, path: docPath, found: Boolean(id) };
 		}
 		case 'rename': {
 			const docId = ctx.getNodeParameter('docId', itemIndex) as string;
@@ -62,7 +63,12 @@ export async function handleDocumentOperation(
 		}
 		case 'exportMd': {
 			const docId = ctx.getNodeParameter('docId', itemIndex) as string;
-			return client.exportDocMd(docId);
+			const exported = await client.exportDocMd(docId);
+			return {
+				id: docId,
+				content: exported?.content ?? '',
+				hPath: exported?.hPath ?? '',
+			};
 		}
 		case 'getStoragePath': {
 			const docId = ctx.getNodeParameter('docId', itemIndex) as string;

--- a/nodes/SiYuan/actions/system/system.handler.ts
+++ b/nodes/SiYuan/actions/system/system.handler.ts
@@ -28,7 +28,8 @@ export async function handleSystemOperation(
 		}
 		case 'renderSprig': {
 			const template = ctx.getNodeParameter('sprigTemplate', itemIndex) as string;
-			return client.renderSprig(template);
+			const result = await client.renderSprig(template);
+			return { template, result: result ?? '' };
 		}
 		case 'exportResources': {
 			const pathsStr = ctx.getNodeParameter('exportPaths', itemIndex) as string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-siyuan",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "n8n community nodes for SiYuan — manage notebooks, documents, blocks, tags, assets, and search. Includes AI Tool nodes for use with n8n AI agents and a Trigger node for real-time events.",
   "keywords": [
     "n8n-community-node-package",

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -253,6 +253,60 @@ async function main() {
 			assert(msg.includes('Nope'), 'error message names the bad column', msg);
 		}
 		assert(threw, 'threw on unknown column');
+
+		// -------------------------------------------------------------------
+		// Issue #14a — addRow with blockID omitted auto-resolves from avID
+		// -------------------------------------------------------------------
+		console.log('\n→ #14a: addRow with databaseBlockId blank auto-resolves');
+		const row5 = (await handleDatabaseOperation(
+			client,
+			'addRow',
+			makeCtx({
+				avId,
+				databaseBlockId: '',
+				primaryKeyContent: 'Row Five',
+				addRowMode: 'simple',
+			}) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(row5.databaseBlockId === dbBlockId, 'resolved blockID matches the original', row5);
+		assert(typeof row5.rowID === 'string', 'rowID returned on auto-resolve path', row5);
+
+		// -------------------------------------------------------------------
+		// Issue #14b — Get filter with array value applies OR semantics
+		// -------------------------------------------------------------------
+		console.log('\n→ #14b: get with array-value filter (Title in [Alpha, Beta])');
+		const orFiltered = (await handleDatabaseOperation(
+			client,
+			'get',
+			makeCtx({
+				avId,
+				getOutputMode: 'split',
+				getFilter: JSON.stringify({ Title: ['Alpha', 'Beta'] }),
+			}) as any,
+			0,
+		)) as Array<Record<string, unknown>>;
+		assert(orFiltered.length === 2, 'two rows match OR filter', orFiltered.length);
+		const titles = orFiltered.map((r) => r.Title).sort();
+		assert(
+			JSON.stringify(titles) === JSON.stringify(['Alpha', 'Beta']),
+			'returned Alpha and Beta',
+			titles,
+		);
+
+		console.log('\n→ #14b: mixed AND + OR filter ({Title:[Alpha,Beta], Done:true})');
+		const mixed = (await handleDatabaseOperation(
+			client,
+			'get',
+			makeCtx({
+				avId,
+				getOutputMode: 'split',
+				getFilter: JSON.stringify({ Title: ['Alpha', 'Beta'], Done: true }),
+			}) as any,
+			0,
+		)) as Array<Record<string, unknown>>;
+		assert(mixed.length === 1, 'one row matches mixed AND+OR', mixed.length);
+		assert(mixed[0].Title === 'Alpha', 'mixed AND+OR returns the Done row only', mixed[0]);
 	} finally {
 		console.log(`\n→ cleanup: removing notebook ${notebookId}`);
 		try {

--- a/tests/integration/primitive-returns.test.ts
+++ b/tests/integration/primitive-returns.test.ts
@@ -1,0 +1,173 @@
+/* eslint-disable no-console */
+/**
+ * Integration test for the v2.1.2 fixes (issue #10 resurfaced on Document → Create
+ * in v2.1.1; same primitive-return pattern as #4, #6, #9). Five operations still
+ * passed raw strings through `returnJsonArray()`, causing n8n's Table view to split
+ * each character into its own column.
+ *
+ * Confirms every handler now returns a named object (not a primitive):
+ *   - document.create        → { id, notebookId, path, found }
+ *   - document.exportMd      → { id, content }
+ *   - block.getContentMd     → { id, content }
+ *   - system.renderSprig     → { template, result }
+ *   - asset.getFile          → { path, content }
+ *
+ * Usage:
+ *   SIYUAN_URL=http://10.0.0.101:6806 SIYUAN_TOKEN=... pnpm tsx tests/integration/primitive-returns.test.ts
+ */
+import { SiYuanClient } from '../../lib/SiYuanClient';
+import { handleDocumentOperation } from '../../nodes/SiYuan/actions/document/document.handler';
+import { handleBlockOperation } from '../../nodes/SiYuan/actions/block/block.handler';
+import { handleSystemOperation } from '../../nodes/SiYuan/actions/system/system.handler';
+import { handleAssetOperation } from '../../nodes/SiYuan/actions/asset/asset.handler';
+
+const url = process.env.SIYUAN_URL;
+const token = process.env.SIYUAN_TOKEN;
+if (!url || !token) {
+	console.error('Set SIYUAN_URL and SIYUAN_TOKEN env vars.');
+	process.exit(2);
+}
+
+const client = new SiYuanClient(url, token);
+
+let failures = 0;
+function ok(label: string) {
+	console.log(`  ✓ ${label}`);
+}
+function fail(label: string, detail: unknown) {
+	failures += 1;
+	console.log(`  ✗ ${label}`);
+	console.log(`     ${typeof detail === 'string' ? detail : JSON.stringify(detail)}`);
+}
+function assert(cond: unknown, label: string, detail?: unknown) {
+	if (cond) ok(label);
+	else fail(label, detail);
+}
+
+function isPlainObject(v: unknown): boolean {
+	return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function makeCtx(params: Record<string, unknown>): any {
+	return {
+		getNodeParameter(name: string, _i: number, fallback?: unknown): unknown {
+			if (name in params) return params[name];
+			return fallback;
+		},
+		helpers: {
+			// asset.uploadFile path isn't exercised here; getFile only.
+		},
+	};
+}
+
+async function main() {
+	const notebookName = `n8n-prim-${Date.now()}`;
+	console.log(`\n→ creating throwaway notebook "${notebookName}"`);
+	const notebook = await client.createNotebook(notebookName);
+	const notebookId = notebook.id;
+
+	try {
+		// -------------------------------------------------------------------
+		// document.create — the operation in Stéphane's v2.1.1 screenshot
+		// -------------------------------------------------------------------
+		console.log('\n→ document.create returns named object, not raw doc ID');
+		const create = (await handleDocumentOperation(
+			client,
+			'create',
+			makeCtx({
+				notebookId,
+				docPath: '/prim-test',
+				markdownContent: '# Primitive returns test\n\nBody.',
+			}) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(isPlainObject(create), 'returns a plain object', create);
+		assert(typeof create.id === 'string' && (create.id as string).length > 0, 'id populated', create);
+		assert(create.notebookId === notebookId, 'notebookId echoed', create);
+		assert(create.path === '/prim-test', 'path echoed', create);
+		assert(create.found === true, 'found=true', create);
+		const docId = create.id as string;
+
+		// -------------------------------------------------------------------
+		// document.exportMd
+		// -------------------------------------------------------------------
+		console.log('\n→ document.exportMd returns { id, content }');
+		const exp = (await handleDocumentOperation(
+			client,
+			'exportMd',
+			makeCtx({ docId }) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(isPlainObject(exp), 'returns a plain object', exp);
+		assert(exp.id === docId, 'id echoed', exp);
+		assert(typeof exp.content === 'string', 'content is a string', exp);
+		assert((exp.content as string).includes('Primitive returns test'), 'content contains the body', exp);
+
+		// -------------------------------------------------------------------
+		// block.getContentMd — append a block first, then read it back
+		// -------------------------------------------------------------------
+		console.log('\n→ block.getContentMd returns { id, content }');
+		const appended = await client.appendBlock(docId, '## Section\n\npara content', 'markdown');
+		const newBlockId = appended?.[0]?.doOperations?.[0]?.id;
+		assert(typeof newBlockId === 'string', 'appendBlock returned a new block id', appended);
+		if (typeof newBlockId === 'string') {
+			const blockContent = (await handleBlockOperation(
+				client,
+				'getContentMd',
+				makeCtx({ blockId: newBlockId }) as any,
+				0,
+			)) as Record<string, unknown>;
+			assert(isPlainObject(blockContent), 'returns a plain object', blockContent);
+			assert(blockContent.id === newBlockId, 'id echoed', blockContent);
+			assert(typeof blockContent.content === 'string', 'content is a string', blockContent);
+		}
+
+		// -------------------------------------------------------------------
+		// system.renderSprig
+		// -------------------------------------------------------------------
+		console.log('\n→ system.renderSprig returns { template, result }');
+		const sprig = (await handleSystemOperation(
+			client,
+			'renderSprig',
+			makeCtx({ sprigTemplate: '{{ "hello" | upper }}' }) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(isPlainObject(sprig), 'returns a plain object', sprig);
+		assert(sprig.template === '{{ "hello" | upper }}', 'template echoed', sprig);
+		assert(typeof sprig.result === 'string', 'result is a string', sprig);
+		assert(sprig.result === 'HELLO', 'sprig rendered uppercase', sprig);
+
+		// -------------------------------------------------------------------
+		// asset.getFile — write a tiny file via putFile then read via getFile
+		// -------------------------------------------------------------------
+		console.log('\n→ asset.getFile returns { path, content }');
+		const assetPath = `data/${notebookId}/n8n-prim.txt`;
+		await client.putFile(assetPath, 'just-some-bytes', false);
+		const got = (await handleAssetOperation(
+			client,
+			'getFile',
+			makeCtx({ filePath: assetPath }) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(isPlainObject(got), 'returns a plain object', got);
+		assert(got.path === assetPath, 'path echoed', got);
+		assert(typeof got.content === 'string', 'content is a string', got);
+		assert((got.content as string).includes('just-some-bytes'), 'content roundtrip', got);
+	} finally {
+		console.log(`\n→ cleanup: removing notebook ${notebookId}`);
+		try {
+			await client.removeNotebook(notebookId);
+			console.log('  cleanup ok');
+		} catch (e) {
+			console.log(`  cleanup failed: ${(e as Error).message}`);
+		}
+	}
+
+	console.log(`\n${failures === 0 ? '✅ ALL CHECKS PASSED' : `❌ ${failures} CHECK(S) FAILED`}`);
+	process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+	console.error('Unexpected error:', e);
+	process.exit(1);
+});

--- a/tests/playwright/n8n-smoke.spec.ts
+++ b/tests/playwright/n8n-smoke.spec.ts
@@ -1,6 +1,7 @@
 /**
- * Playwright smoke test for v2.1.1 — drives the n8n UI on 10.0.0.108:5678 to verify
- * the user-facing fixes for issues #9, #10, #12 work end-to-end in the actual node.
+ * Playwright smoke test for v2.1.2 — drives the n8n UI on 10.0.0.108:5678 to verify
+ * the user-facing fixes for issues #9, #10, #12 (v2.1.1) and #10 (resurfaced on
+ * Document → Create) + #14 (Database UX, OR filter) for v2.1.2.
  *
  * Auth strategy: the n8n instance requires email login. We bootstrap the UI session by
  * exchanging the existing API key (from env N8N_API_KEY) for a cookie via the public API,
@@ -28,7 +29,7 @@ interface CreatedWorkflow {
 
 const headers = { 'X-N8N-API-KEY': N8N_API_KEY, 'Content-Type': 'application/json' };
 
-test.describe('n8n SiYuan nodes 2.1.1 smoke', () => {
+test.describe('n8n SiYuan nodes 2.1.2 smoke', () => {
 	let workflowId: string | null = null;
 
 	test.afterAll(async () => {
@@ -43,7 +44,7 @@ test.describe('n8n SiYuan nodes 2.1.1 smoke', () => {
 		// Build a small workflow that exercises the three nodes most likely to expose
 		// the bug surface: getDocumentTree (#9), database.list (#12c), database.get split (#12b).
 		const workflow = {
-			name: `siyuan-2.1.1-smoke-${Date.now()}`,
+			name: `siyuan-2.1.2-smoke-${Date.now()}`,
 			nodes: [
 				{
 					parameters: {},
@@ -97,5 +98,108 @@ test.describe('n8n SiYuan nodes 2.1.1 smoke', () => {
 		const listNode = wf.nodes.find((n) => (n as any).name === 'Database List')!;
 		expect(listNode.parameters.resource).toBe('database');
 		expect(listNode.parameters.operation).toBe('list');
+	});
+
+	test('v2.1.2 new parameter shapes round-trip through n8n API', async () => {
+		// Confirms the v2.1.2 parameter schema (optional databaseBlockId, byColumnName default,
+		// array-value filter) survives a create→fetch cycle without n8n stripping or rejecting it.
+		const api = await pwRequest.newContext({ baseURL: N8N_URL, extraHTTPHeaders: headers });
+
+		const workflow = {
+			name: `siyuan-2.1.2-params-${Date.now()}`,
+			nodes: [
+				{
+					parameters: {},
+					id: 'manual',
+					name: 'Manual Trigger',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [200, 300] as [number, number],
+				},
+				{
+					parameters: {
+						resource: 'document',
+						operation: 'create',
+						notebookId: '00000000000000-test',
+						docPath: '/round-trip',
+						markdownContent: '# hi',
+					},
+					id: 'doc-create',
+					name: 'Document Create',
+					type: 'n8n-nodes-siyuan.siYuan',
+					typeVersion: 1,
+					position: [500, 200] as [number, number],
+					credentials: { siYuanApi: { id: SIYUAN_CREDENTIAL_ID, name: 'SiYuan account' } },
+				},
+				{
+					parameters: {
+						resource: 'database',
+						operation: 'addRow',
+						avId: '00000000000000-av',
+						// databaseBlockId intentionally omitted — should auto-resolve at execution.
+						primaryKeyContent: 'Round Trip',
+						addRowMode: 'fields',
+						fieldsMode: 'byColumnName',
+						fieldsByColumnName: '{"Title":"X"}',
+					},
+					id: 'db-addrow',
+					name: 'Database AddRow',
+					type: 'n8n-nodes-siyuan.siYuan',
+					typeVersion: 1,
+					position: [500, 400] as [number, number],
+					credentials: { siYuanApi: { id: SIYUAN_CREDENTIAL_ID, name: 'SiYuan account' } },
+				},
+				{
+					parameters: {
+						resource: 'database',
+						operation: 'get',
+						avId: '00000000000000-av',
+						getOutputMode: 'split',
+						getFilter: '{"Status":["Done","WIP"]}',
+					},
+					id: 'db-get',
+					name: 'Database Get',
+					type: 'n8n-nodes-siyuan.siYuan',
+					typeVersion: 1,
+					position: [500, 600] as [number, number],
+					credentials: { siYuanApi: { id: SIYUAN_CREDENTIAL_ID, name: 'SiYuan account' } },
+				},
+			],
+			connections: {
+				'Manual Trigger': {
+					main: [[
+						{ node: 'Document Create', type: 'main', index: 0 },
+						{ node: 'Database AddRow', type: 'main', index: 0 },
+						{ node: 'Database Get', type: 'main', index: 0 },
+					]],
+				},
+			},
+			settings: { executionOrder: 'v1' },
+		};
+
+		const created = await api.post('/api/v1/workflows', { data: workflow });
+		expect(created.ok(), `create: ${created.status()} ${await created.text()}`).toBeTruthy();
+		const body = (await created.json()) as CreatedWorkflow;
+		const id = body.id;
+
+		try {
+			const fetched = await api.get(`/api/v1/workflows/${id}`);
+			const wf = (await fetched.json()) as { nodes: Array<{ name: string; parameters: Record<string, unknown> }> };
+
+			const addRow = wf.nodes.find((n) => n.name === 'Database AddRow')!;
+			expect(addRow.parameters.fieldsMode).toBe('byColumnName');
+			// databaseBlockId may be absent or empty — both indicate "leave blank for auto-resolve".
+			const dbId = addRow.parameters.databaseBlockId as string | undefined;
+			expect(dbId === undefined || dbId === '').toBeTruthy();
+
+			const get = wf.nodes.find((n) => n.name === 'Database Get')!;
+			expect(get.parameters.getFilter).toBe('{"Status":["Done","WIP"]}');
+
+			const docCreate = wf.nodes.find((n) => n.name === 'Document Create')!;
+			expect(docCreate.parameters.operation).toBe('create');
+			expect(docCreate.parameters.markdownContent).toBe('# hi');
+		} finally {
+			await api.delete(`/api/v1/workflows/${id}`).catch(() => undefined);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Closes #10 and #14.

### Issue #10 — Document → Create output malformed (resurfaced in v2.1.1)

The v2.1.1 fix addressed Database → Create only. Stéphane's follow-up screenshot showed the bug is actually on **Document → Create** — same primitive-string leak as #4, #6, #9. Wraps the four remaining offenders at the handler boundary so `returnJsonArray()` has a key to assign to:

| Operation | New shape |
|---|---|
| `document.create`     | `{ id, notebookId, path, found }` |
| `document.exportMd`   | `{ id, content, hPath }` (already an object — flattened with `id`) |
| `block.getContentMd`  | `{ id, content }` |
| `system.renderSprig`  | `{ template, result }` |
| `asset.getFile`       | `{ path, content }` |

### Issue #14 — Database Add Row + Get feedback

1. **Add Row no longer requires Database Block ID.** It's now optional; if left blank the handler resolves it from the AV ID via a single SQL lookup (`getBlockIdByAvId`). Power users can still set it explicitly to skip the round-trip. The output also exposes the resolved `databaseBlockId` so downstream nodes don't need to look it up again.
2. **Fields mode now defaults to *By Column Name*.** Raw key IDs were unusable for hand-authored workflows. `byKeyId` is still available for advanced uses; option order was flipped so the friendly mode is first.
3. **Get filter now supports OR via array values.** Backward-compatible:
   ```jsonc
   {"Status":"Done","Owner":"Mike"}             // AND across keys (unchanged)
   {"Status":["Done","WIP"]}                    // OR on one column (new)
   {"Status":["Done","WIP"],"Owner":"Mike"}     // mixed
   ```
   Scalar values keep `===` semantics so every existing filter still works.

Bumps to v2.1.2.

## Test plan

- [x] `pnpm build` — TypeScript compiles clean
- [x] `tests/integration/primitive-returns.test.ts` — 18 assertions green against live SiYuan 3.6.3 at 10.0.0.101:6806 (throwaway notebook; the four new wraps + the corrected `exportMd` shape)
- [x] `tests/integration/database.test.ts` — extended with 5 new checks (auto-resolve, array-OR, mixed AND+OR); 33 assertions total green
- [x] Playwright API-round-trip spec extended with the v2.1.2 parameter shapes (n8n accepts them without stripping)
- [ ] After merge: `pnpm publish --access public --no-git-checks` → v2.1.2 on npm
- [ ] After publish: `npm install -g n8n-nodes-siyuan@2.1.2` on the n8n LXC + restart