### PR TITLE
v2.1.3 — Update Row + By Column Name & Value fields mode

### DIFF
--- a/nodes/SiYuan/actions/database/database.description.ts
+++ b/nodes/SiYuan/actions/database/database.description.ts
@@ -61,6 +61,12 @@ export const databaseOperations: INodeProperties = {
 			description: 'Set the value of a cell in a database row',
 			action: 'Set a cell value in a database',
 		},
+		{
+			name: 'Update Row',
+			value: 'updateRow',
+			description: 'Update multiple cell values in an existing row in one operation',
+			action: 'Update a row in a database',
+		},
 	],
 	default: 'list',
 };
@@ -90,6 +96,7 @@ export const databaseFields: INodeProperties[] = [
 					'get',
 					'getSchema',
 					'addRow',
+					'updateRow',
 					'removeRow',
 					'addColumn',
 					'removeColumn',
@@ -116,47 +123,71 @@ export const databaseFields: INodeProperties[] = [
 		displayOptions: { show: { resource: ['database'], operation: ['addRow'] } },
 	},
 	{
-		displayName: 'Add Row Mode',
-		name: 'addRowMode',
-		type: 'options',
-		default: 'simple',
-		description:
-			'Whether to create the row blank (simple) or set additional column values at the same time (fields)',
-		displayOptions: { show: { resource: ['database'], operation: ['addRow'] } },
-		options: [
-			{
-				name: 'Simple (Primary Key Only)',
-				value: 'simple',
-				description: 'Create a blank row with only the primary key set',
-			},
-			{
-				name: 'With Fields',
-				value: 'fields',
-				description: 'Set additional column values during creation',
-			},
-		],
-	},
-	{
 		displayName: 'Fields Mode',
 		name: 'fieldsMode',
 		type: 'options',
-		default: 'byColumnName',
-		description: 'How to identify the columns to set',
+		default: 'byNameAndValue',
+		description: 'How to identify the columns to set. Leave the chosen mode\'s collection empty to create or keep a row without setting any fields.',
 		displayOptions: {
-			show: { resource: ['database'], operation: ['addRow'], addRowMode: ['fields'] },
+			show: { resource: ['database'], operation: ['addRow', 'updateRow'] },
 		},
 		options: [
+			{
+				name: 'By Column Name & Value (Collection)',
+				value: 'byNameAndValue',
+				description:
+					'Per-row UI — pick a column name and type the value as a plain string. Recommended for most workflows; avoids JSON quoting concerns when using n8n expressions.',
+			},
 			{
 				name: 'By Column Name (JSON)',
 				value: 'byColumnName',
 				description:
-					'JSON object mapping column display names to values — recommended for most use cases',
+					'JSON object mapping column display names to values. Useful when computing the payload dynamically (e.g. from a Code node).',
 			},
 			{
 				name: 'By Column (Key) ID',
 				value: 'byKeyId',
 				description:
-					'Repeat field with explicit keyID + value entries — use when you have the internal column IDs',
+					'Repeat field with explicit keyID + value entries — use when you already have the internal column IDs',
+			},
+		],
+	},
+	{
+		displayName: 'Fields',
+		name: 'fieldsByNameAndValue',
+		type: 'fixedCollection',
+		typeOptions: { multipleValues: true },
+		default: {},
+		description:
+			'Column-name + value pairs. The value is a plain string; n8n expressions work directly here without needing JSON-style quoting. Booleans/numbers/dates are coerced based on the column type.',
+		displayOptions: {
+			show: {
+				resource: ['database'],
+				operation: ['addRow', 'updateRow'],
+				fieldsMode: ['byNameAndValue'],
+			},
+		},
+		options: [
+			{
+				name: 'field',
+				displayName: 'Field',
+				values: [
+					{
+						displayName: 'Column Name',
+						name: 'columnName',
+						type: 'string',
+						default: '',
+						description: 'The display name of the column to set',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						description:
+							'Value for the cell. n8n expressions like {{ $JSON.x }} render here without needing outer quotes.',
+					},
+				],
 			},
 		],
 	},
@@ -166,12 +197,11 @@ export const databaseFields: INodeProperties[] = [
 		type: 'fixedCollection',
 		typeOptions: { multipleValues: true },
 		default: {},
-		description: 'Field/value pairs to set on the new row',
+		description: 'Field/value pairs to set on the row, keyed by internal column ID',
 		displayOptions: {
 			show: {
 				resource: ['database'],
-				operation: ['addRow'],
-				addRowMode: ['fields'],
+				operation: ['addRow', 'updateRow'],
 				fieldsMode: ['byKeyId'],
 			},
 		},
@@ -206,12 +236,12 @@ export const databaseFields: INodeProperties[] = [
 		typeOptions: { rows: 4 },
 		default: '',
 		placeholder: '{ "Title": "Hello", "Done": true }',
-		description: 'JSON object mapping column display names to values',
+		description:
+			'JSON object mapping column display names to values. Note: n8n expressions still need outer quotes for string columns — switch to "By Column Name & Value (Collection)" to skip that concern.',
 		displayOptions: {
 			show: {
 				resource: ['database'],
-				operation: ['addRow'],
-				addRowMode: ['fields'],
+				operation: ['addRow', 'updateRow'],
 				fieldsMode: ['byColumnName'],
 			},
 		},
@@ -255,7 +285,7 @@ export const databaseFields: INodeProperties[] = [
 		required: true,
 		default: '',
 		description: 'The ID of the row to operate on',
-		displayOptions: { show: { resource: ['database'], operation: ['removeRow', 'setCell'] } },
+		displayOptions: { show: { resource: ['database'], operation: ['removeRow', 'setCell', 'updateRow'] } },
 	},
 	{
 		displayName: 'Column (Key) ID',

--- a/nodes/SiYuan/actions/database/database.handler.ts
+++ b/nodes/SiYuan/actions/database/database.handler.ts
@@ -42,6 +42,106 @@ function applyFilter(rows: Record<string, unknown>[], filter: Record<string, unk
 	);
 }
 
+type FieldsMode = 'byNameAndValue' | 'byColumnName' | 'byKeyId';
+
+/**
+ * Resolve a list of column-name + value pairs into key-ID + value pairs by
+ * looking up the AV schema once. Throws with a helpful message when a name
+ * doesn't exist so users learn the correct spelling.
+ */
+async function resolvePairsByName(
+	client: SiYuanClient,
+	avId: string,
+	rows: Array<{ columnName: string; value: unknown }>,
+): Promise<Array<{ keyId: string; value: unknown }>> {
+	if (rows.length === 0) return [];
+	const view = await client.renderDatabase(avId);
+	const byName = new Map(view.columns.map((c) => [c.name, c.id]));
+	return rows.map((r) => {
+		const keyId = byName.get(r.columnName);
+		if (!keyId) {
+			throw new Error(
+				`Column "${r.columnName}" not found in database. Existing columns: ${[...byName.keys()].join(', ')}`,
+			);
+		}
+		return { keyId, value: r.value };
+	});
+}
+
+/**
+ * Read the user's field input for the selected mode and resolve everything to
+ * `{ keyId, value }` pairs ready for setDatabaseCell.
+ *
+ * - `byNameAndValue` — fixedCollection of {columnName,value} rows. The
+ *   recommended default; sidesteps JSON quoting entirely so n8n expressions
+ *   work in plain string fields (issue #16).
+ * - `byColumnName` — JSON object {"Name": value, ...}. Useful for users who
+ *   compute the payload in a Code/Function node.
+ * - `byKeyId` — fixedCollection of {keyId,value} rows. Power-user mode.
+ */
+async function collectFieldPairs(
+	client: SiYuanClient,
+	ctx: IExecuteFunctions,
+	itemIndex: number,
+	avId: string,
+	fieldsMode: FieldsMode,
+): Promise<Array<{ keyId: string; value: unknown }>> {
+	if (fieldsMode === 'byKeyId') {
+		const raw = ctx.getNodeParameter(
+			'fieldsByKeyId.field',
+			itemIndex,
+			[],
+		) as Array<{ keyId: string; value: string }>;
+		return raw
+			.filter((r) => r && r.keyId)
+			.map((r) => ({ keyId: r.keyId, value: r.value }));
+	}
+
+	if (fieldsMode === 'byNameAndValue') {
+		const raw = ctx.getNodeParameter(
+			'fieldsByNameAndValue.field',
+			itemIndex,
+			[],
+		) as Array<{ columnName: string; value: string }>;
+		const rows = raw
+			.filter((r) => r && r.columnName)
+			.map((r) => ({ columnName: r.columnName, value: r.value }));
+		return resolvePairsByName(client, avId, rows);
+	}
+
+	// byColumnName — JSON object input.
+	const jsonRaw = ctx.getNodeParameter('fieldsByColumnName', itemIndex, '') as string;
+	if (!jsonRaw || jsonRaw.trim().length === 0) return [];
+	let parsed: Record<string, unknown>;
+	try {
+		parsed = JSON.parse(jsonRaw);
+	} catch (e) {
+		throw new Error(
+			`Invalid Fields JSON: ${(e as Error).message}. Expected {"Column Name": value}. ` +
+				`Tip: in n8n template syntax, string values still need outer quotes — e.g. "Name":"{{ $json.name }}". ` +
+				`Switch Fields Mode to "By Column Name & Value (Collection)" to skip the quoting concern entirely.`,
+		);
+	}
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		throw new Error('Fields JSON must be an object {"Column Name": value}.');
+	}
+	const rows = Object.entries(parsed).map(([columnName, value]) => ({ columnName, value }));
+	return resolvePairsByName(client, avId, rows);
+}
+
+/** Apply a list of {keyId, value} pairs as cell updates. Returns the number applied. */
+async function applyCellUpdates(
+	client: SiYuanClient,
+	avId: string,
+	rowID: string,
+	pairs: Array<{ keyId: string; value: unknown }>,
+): Promise<number> {
+	for (const { keyId, value } of pairs) {
+		await client.setDatabaseCell(avId, rowID, keyId, value);
+	}
+	return pairs.length;
+}
+
 export async function handleDatabaseOperation(
 	client: SiYuanClient,
 	operation: string,
@@ -138,61 +238,12 @@ export async function handleDatabaseOperation(
 				? databaseBlockIdRaw.trim()
 				: await client.getBlockIdByAvId(avId);
 			const primaryContent = ctx.getNodeParameter('primaryKeyContent', itemIndex, '') as string;
-			const addRowMode = ctx.getNodeParameter('addRowMode', itemIndex, 'simple') as
-				| 'simple'
-				| 'fields';
 
 			const { rowID } = await client.addDatabaseRow(avId, databaseBlockId, primaryContent);
 
-			let fieldsSet = 0;
-			if (addRowMode === 'fields') {
-				const fieldsMode = ctx.getNodeParameter('fieldsMode', itemIndex, 'byColumnName') as
-					| 'byKeyId'
-					| 'byColumnName';
-
-				const pairs: Array<{ keyId: string; value: unknown }> = [];
-
-				if (fieldsMode === 'byKeyId') {
-					const raw = ctx.getNodeParameter(
-						'fieldsByKeyId.field',
-						itemIndex,
-						[],
-					) as Array<{ keyId: string; value: string }>;
-					for (const r of raw) {
-						if (r.keyId) pairs.push({ keyId: r.keyId, value: r.value });
-					}
-				} else {
-					const jsonRaw = ctx.getNodeParameter('fieldsByColumnName', itemIndex, '') as string;
-					if (jsonRaw && jsonRaw.trim().length > 0) {
-						let parsed: Record<string, unknown>;
-						try {
-							parsed = JSON.parse(jsonRaw);
-						} catch (e) {
-							throw new Error(
-								`Invalid Fields JSON: ${(e as Error).message}. Expected {"Column Name": value}.`,
-							);
-						}
-						if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-							throw new Error('Fields JSON must be an object {"Column Name": value}.');
-						}
-						// Resolve column NAMES → keyIDs (one renderDatabase call).
-						const view = await client.renderDatabase(avId);
-						const byName = new Map(view.columns.map((c) => [c.name, c.id]));
-						for (const [name, value] of Object.entries(parsed)) {
-							const keyId = byName.get(name);
-							if (!keyId) {
-								throw new Error(`Column "${name}" not found in database. Existing columns: ${[...byName.keys()].join(', ')}`);
-							}
-							pairs.push({ keyId, value });
-						}
-					}
-				}
-
-				for (const { keyId, value } of pairs) {
-					await client.setDatabaseCell(avId, rowID, keyId, value);
-					fieldsSet += 1;
-				}
-			}
+			const fieldsMode = ctx.getNodeParameter('fieldsMode', itemIndex, 'byNameAndValue') as FieldsMode;
+			const pairs = await collectFieldPairs(client, ctx, itemIndex, avId, fieldsMode);
+			const fieldsSet = await applyCellUpdates(client, avId, rowID, pairs);
 
 			return {
 				avID: avId,
@@ -201,6 +252,15 @@ export async function handleDatabaseOperation(
 				primaryKeyContent: primaryContent,
 				fieldsSet,
 			};
+		}
+
+		case 'updateRow': {
+			const avId = ctx.getNodeParameter('avId', itemIndex) as string;
+			const rowId = ctx.getNodeParameter('rowId', itemIndex) as string;
+			const fieldsMode = ctx.getNodeParameter('fieldsMode', itemIndex, 'byNameAndValue') as FieldsMode;
+			const pairs = await collectFieldPairs(client, ctx, itemIndex, avId, fieldsMode);
+			const fieldsSet = await applyCellUpdates(client, avId, rowId, pairs);
+			return { avID: avId, rowID: rowId, fieldsSet };
 		}
 
 		case 'removeRow': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-siyuan",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "n8n community nodes for SiYuan — manage notebooks, documents, blocks, tags, assets, and search. Includes AI Tool nodes for use with n8n AI agents and a Trigger node for real-time events.",
   "keywords": [
     "n8n-community-node-package",

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -307,6 +307,139 @@ async function main() {
 		)) as Array<Record<string, unknown>>;
 		assert(mixed.length === 1, 'one row matches mixed AND+OR', mixed.length);
 		assert(mixed[0].Title === 'Alpha', 'mixed AND+OR returns the Done row only', mixed[0]);
+
+		// -------------------------------------------------------------------
+		// Issue #16 — Add Row with new "By Column Name & Value" collection mode
+		// -------------------------------------------------------------------
+		console.log('\n→ #16: addRow with byNameAndValue collection (Sigma row)');
+		const rowSigma = (await handleDatabaseOperation(
+			client,
+			'addRow',
+			makeCtx({
+				avId,
+				databaseBlockId: dbBlockId,
+				primaryKeyContent: 'Row Sigma',
+				fieldsMode: 'byNameAndValue',
+				'fieldsByNameAndValue.field': [
+					{ columnName: 'Title', value: 'Sigma' },
+					{ columnName: 'Count', value: '15' },
+					{ columnName: 'Done', value: 'true' },
+				],
+			}) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(rowSigma.fieldsSet === 3, 'fieldsSet === 3 (byNameAndValue)', rowSigma);
+		assert(typeof rowSigma.rowID === 'string', 'rowID present (byNameAndValue)', rowSigma);
+
+		const getSigma = (await handleDatabaseOperation(
+			client,
+			'get',
+			makeCtx({ avId, getOutputMode: 'split', getFilter: JSON.stringify({ Title: 'Sigma' }) }) as any,
+			0,
+		)) as Array<Record<string, unknown>>;
+		assert(getSigma.length === 1, 'find Sigma row via get filter', getSigma);
+		assert(getSigma[0].Count === 15, 'Count coerced to number 15', getSigma[0]);
+		assert(getSigma[0].Done === true, 'Done coerced to boolean true', getSigma[0]);
+
+		// -------------------------------------------------------------------
+		// Issue #17 — updateRow with all three field modes
+		// -------------------------------------------------------------------
+		const sigmaRowID = rowSigma.rowID as string;
+
+		console.log('\n→ #17: updateRow with byNameAndValue (Count→99, Done→false)');
+		const upd1 = (await handleDatabaseOperation(
+			client,
+			'updateRow',
+			makeCtx({
+				avId,
+				rowId: sigmaRowID,
+				fieldsMode: 'byNameAndValue',
+				'fieldsByNameAndValue.field': [
+					{ columnName: 'Count', value: '99' },
+					{ columnName: 'Done', value: 'false' },
+				],
+			}) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(upd1.fieldsSet === 2, 'fieldsSet === 2 (byNameAndValue update)', upd1);
+		assert(upd1.rowID === sigmaRowID, 'updateRow echoes the rowID', upd1);
+
+		const verifyUpd1 = (await handleDatabaseOperation(
+			client,
+			'get',
+			makeCtx({ avId, getOutputMode: 'split', getFilter: JSON.stringify({ Title: 'Sigma' }) }) as any,
+			0,
+		)) as Array<Record<string, unknown>>;
+		assert(verifyUpd1[0].Count === 99, 'Count is now 99 after update', verifyUpd1[0]);
+		assert(verifyUpd1[0].Done === false, 'Done is now false after update', verifyUpd1[0]);
+
+		console.log('\n→ #17: updateRow with byColumnName JSON (Title→"Sigma Prime")');
+		const upd2 = (await handleDatabaseOperation(
+			client,
+			'updateRow',
+			makeCtx({
+				avId,
+				rowId: sigmaRowID,
+				fieldsMode: 'byColumnName',
+				fieldsByColumnName: JSON.stringify({ Title: 'Sigma Prime' }),
+			}) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(upd2.fieldsSet === 1, 'fieldsSet === 1 (byColumnName update)', upd2);
+
+		const verifyUpd2 = (await handleDatabaseOperation(
+			client,
+			'get',
+			makeCtx({ avId, getOutputMode: 'split', getFilter: JSON.stringify({ Title: 'Sigma Prime' }) }) as any,
+			0,
+		)) as Array<Record<string, unknown>>;
+		assert(verifyUpd2.length === 1, 'found row by new Title after update', verifyUpd2);
+
+		console.log('\n→ #17: updateRow with byKeyId (Count→7)');
+		const upd3 = (await handleDatabaseOperation(
+			client,
+			'updateRow',
+			makeCtx({
+				avId,
+				rowId: sigmaRowID,
+				fieldsMode: 'byKeyId',
+				'fieldsByKeyId.field': [{ keyId: colNum.keyID, value: '7' }],
+			}) as any,
+			0,
+		)) as Record<string, unknown>;
+		assert(upd3.fieldsSet === 1, 'fieldsSet === 1 (byKeyId update)', upd3);
+
+		const verifyUpd3 = (await handleDatabaseOperation(
+			client,
+			'get',
+			makeCtx({ avId, getOutputMode: 'split', getFilter: JSON.stringify({ Title: 'Sigma Prime' }) }) as any,
+			0,
+		)) as Array<Record<string, unknown>>;
+		assert(verifyUpd3[0].Count === 7, 'Count is 7 after byKeyId update', verifyUpd3[0]);
+
+		console.log('\n→ #17: updateRow with unknown column throws clear error');
+		let updThrew = false;
+		try {
+			await handleDatabaseOperation(
+				client,
+				'updateRow',
+				makeCtx({
+					avId,
+					rowId: sigmaRowID,
+					fieldsMode: 'byNameAndValue',
+					'fieldsByNameAndValue.field': [{ columnName: 'NopeColumn', value: 'x' }],
+				}) as any,
+				0,
+			);
+		} catch (e) {
+			updThrew = true;
+			assert(
+				(e as Error).message.includes('NopeColumn'),
+				'error names the missing column',
+				(e as Error).message,
+			);
+		}
+		assert(updThrew, 'threw on unknown column in updateRow');
 	} finally {
 		console.log(`\n→ cleanup: removing notebook ${notebookId}`);
 		try {


### PR DESCRIPTION
## Summary

Closes #16 and #17.

### Issue #16 — JSON quoting confusion on Add Row

In v2.1.2 the *By Column Name (JSON)* fields mode forces type-aware quoting on n8n expressions: string columns need outer quotes (`"Firstname":"{{ \$json.Firstname }}"`) but numeric columns must not (`"Rank":{{ \$json.rank }}`). Asymmetry is confusing.

**Fix:** New default field mode — **By Column Name & Value (Collection)**. A fixedCollection of `{ columnName, value }` rows; each value is a plain string input where n8n expressions render directly. No JSON parsing, no quoting concerns.

Three modes available now (in display order):
1. By Column Name & Value (Collection) — new default
2. By Column Name (JSON) — kept for users who compute the payload in code nodes
3. By Column (Key) ID — power-user mode

Also: dropped the `addRowMode` (Simple / With Fields) parameter. It was UI sugar to hide field inputs; with three modes available the inputs always belong on screen, and an empty collection still produces a blank row (`fieldsSet=0`). Saved workflows that set `addRowMode` keep working — the parameter becomes inert. The JSON-mode error message also now points users at the new collection mode.

### Issue #17 — Update Row missing

New `updateRow` operation updates multiple cells on an existing row in one call. Inputs: AV ID + Row ID + chosen fields collection. Same three field modes as Add Row. Output: `{ avID, rowID, fieldsSet }`.

Refactor: extracted `collectFieldPairs`, `resolvePairsByName`, and `applyCellUpdates` helpers so Add Row and Update Row share one resolution path.

## Test plan

- [x] `pnpm build` + `pnpm lint -c .eslintrc.prepublish.js nodes credentials package.json` — both clean
- [x] `tests/integration/database.test.ts` — extended with 14 new assertions (byNameAndValue addRow + all three updateRow modes + unknown-column error); 47 assertions total green against live SiYuan 3.6.3
- [x] `tests/integration/primitive-returns.test.ts` regression — still green
- [x] After merge: `pnpm publish --access public --no-git-checks` → 2.1.3 on npm
- [x] After publish: bump on the n8n LXC (`npm install -g n8n-nodes-siyuan@2.1.3` + restart) and smoke-test the new UI