### PR TITLE
feat(database): reorder Row ID above Fields on Update Row (v2.1.4)

### DIFF
--- a/nodes/SiYuan/actions/database/database.description.ts
+++ b/nodes/SiYuan/actions/database/database.description.ts
@@ -153,6 +153,15 @@ export const databaseFields: INodeProperties[] = [
 		],
 	},
 	{
+		displayName: 'Row ID',
+		name: 'rowId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The ID of the row to operate on',
+		displayOptions: { show: { resource: ['database'], operation: ['removeRow', 'setCell', 'updateRow'] } },
+	},
+	{
 		displayName: 'Fields',
 		name: 'fieldsByNameAndValue',
 		type: 'fixedCollection',
@@ -277,15 +286,6 @@ export const databaseFields: INodeProperties[] = [
 		description:
 			'Optional JSON object — applied client-side after fetch. Scalar values match by equality and combine with AND across keys. Array values match any-of (OR) within that column. Examples: {"Status":"Done","Owner":"Mike"} (AND); {"Status":["Done","WIP"]} (OR on one column); {"Status":["Done","WIP"],"Owner":"Mike"} (mixed).',
 		displayOptions: { show: { resource: ['database'], operation: ['get'] } },
-	},
-	{
-		displayName: 'Row ID',
-		name: 'rowId',
-		type: 'string',
-		required: true,
-		default: '',
-		description: 'The ID of the row to operate on',
-		displayOptions: { show: { resource: ['database'], operation: ['removeRow', 'setCell', 'updateRow'] } },
 	},
 	{
 		displayName: 'Column (Key) ID',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-siyuan",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "n8n community nodes for SiYuan — manage notebooks, documents, blocks, tags, assets, and search. Includes AI Tool nodes for use with n8n AI agents and a Trigger node for real-time events.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Moves the **Row ID** parameter to render between **Fields Mode** and the **Fields** collection on the Update Row form (closes #17 follow-up QOL ask).
- Pure UI reorder via `database.description.ts` — no handler / runtime / schema change.
- Bumps to `2.1.4`.

After this PR the visible field order is:

```
Update Row:  AV ID → Fields Mode → Row ID → Fields
Remove Row:  AV ID → Row ID                            (unchanged)
Set Cell:    AV ID → Row ID → Column ID → Cell Value   (unchanged)
Add Row:     AV ID → Database Block ID → ... → Fields  (unchanged — rowId gated out)
```

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] Publish-time lint (`eslint -c .eslintrc.prepublish.js`) clean
- [x] Integration test against live SiYuan 3.6.3 — all 47 assertions green
- [x] Primitive-returns regression — all 18 assertions green
- [x] Programmatic render-order check against compiled output — matches target order for all four affected operations

closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)